### PR TITLE
Only works in Admin due to jQuery.noConflict(true)

### DIFF
--- a/geoposition/static/geoposition/geoposition.js
+++ b/geoposition/static/geoposition/geoposition.js
@@ -1,3 +1,8 @@
+if (jQuery != undefined) {
+    var django = {
+        'jQuery':jQuery,
+    }
+}
 (function($) {
     
     window.geopositionMapInit = function() {


### PR DESCRIPTION
django-geolocation assumes jQuery to be in the namespace django which is true for admin only. Most of the sites use jQuery as is in the frontend thus the map widget is not displayed.
