### PR TITLE
Error on serializing models with Django 1.4

### DIFF
--- a/geoposition/fields.py
+++ b/geoposition/fields.py
@@ -2,6 +2,7 @@ from django.db import models
 
 from . import Geoposition
 from .forms import GeopositionField as GeopositionFormField
+from django.utils.encoding import smart_unicode
 
 
 class GeopositionField(models.Field):
@@ -40,7 +41,7 @@ class GeopositionField(models.Field):
     
     def value_to_string(self, obj):
         value = self._get_val_from_obj(obj)
-        return self.get_db_prep_value(value)
+        return smart_unicode(value)
     
     def formfield(self, **kwargs):
         defaults = {


### PR DESCRIPTION
Problem: Models using GeopositionField cannot be serialized in Django 1.4:

```
 ./manage.py dumpdata myapp --traceback
Error: Unable to serialize database: get_db_prep_value() takes at least 3 arguments (2 given)
[...] 
File "[...]/lib/python2.7/site-packages/django/core/serializers/python.py", line 45, in handle_field
    self._current[field.name] = field.value_to_string(obj)
File "[...]/src/django-geoposition/geoposition/fields.py", line 43, in value_to_string
    return self.get_db_prep_value(value)
TypeError: get_db_prep_value() takes at least 3 arguments (2 given)
```

Solution: remove call to get_db_prep_value(), it does nothing anyway
