### PR TITLE
HTTPS instead of HTTP

### DIFF
--- a/geoposition/static/geoposition/geoposition.js
+++ b/geoposition/static/geoposition/geoposition.js
@@ -104,7 +104,7 @@ if (jQuery != undefined) {
     
     $(document).ready(function() {
         var $script = $('<script/>');
-        $script.attr('src', 'http://maps.google.com/maps/api/js?sensor=false&callback=geopositionMapInit');
+        $script.attr('src', 'https://maps.google.com/maps/api/js?sensor=false&callback=geopositionMapInit');
         $script.appendTo('body');
     });
 })(django.jQuery);


### PR DESCRIPTION
Now loads google maps api thru https instead of http. This enables the maps widget on SSL admin sites.

Feel free to merge, cheers,

Ivan
