### PR TITLE
Makes models with Geoposition fields usable in admin inline forms

### DIFF
--- a/geoposition/__init__.py
+++ b/geoposition/__init__.py
@@ -10,15 +10,15 @@ class Geoposition(object):
             latitude = str(latitude)
         if isinstance(longitude, float) or isinstance(longitude, int):
             longitude = str(longitude)
-        
+
         self.latitude = Decimal(latitude)
         self.longitude = Decimal(longitude)
-    
+
     def __unicode__(self):
         return "%s,%s" % (self.latitude, self.longitude)
-    
+
     def __repr__(self):
         return "Geoposition(%s)" % unicode(self)
-    
+
     def __len__(self):
         return len(unicode(self))

--- a/geoposition/fields.py
+++ b/geoposition/fields.py
@@ -8,22 +8,25 @@ from django.utils.encoding import smart_unicode
 class GeopositionField(models.Field):
     description = "A geoposition (latitude and longitude)"
     __metaclass__ = models.SubfieldBase
-    
+
     def __init__(self, *args, **kwargs):
         kwargs['max_length'] = 42
+        if not 'default' in kwargs:
+            kwargs['default'] = "0,0"
         super(GeopositionField, self).__init__(*args, **kwargs)
-    
+
     def get_internal_type(self):
         return 'CharField'
-    
+
     def to_python(self, value):
         if not value:
-            value = [0,0]
+            return Geoposition(0, 0)
         if isinstance(value, Geoposition):
             return value
         if isinstance(value, list):
             return Geoposition(value[0], value[1])
-        
+
+        # default case is string
         value_parts = value.rsplit(',')
         try:
             latitude = value_parts[0]
@@ -33,16 +36,16 @@ class GeopositionField(models.Field):
             longitude = value_parts[1]
         except IndexError:
             longitude = '0.0'
-        
+
         return Geoposition(latitude, longitude)
-    
+
     def get_prep_value(self, value):
         return unicode(value)
-    
+
     def value_to_string(self, obj):
         value = self._get_val_from_obj(obj)
         return smart_unicode(value)
-    
+
     def formfield(self, **kwargs):
         defaults = {
             'form_class': GeopositionFormField

--- a/geoposition/forms.py
+++ b/geoposition/forms.py
@@ -2,25 +2,30 @@ from django import forms
 from django.utils.translation import ugettext_lazy as _
 
 from .widgets import GeopositionWidget
+from . import Geoposition
+
 
 class GeopositionField(forms.MultiValueField):
     default_error_messages = {
         'invalid': _('Enter a valid geoposition.')
     }
-    
+
     def __init__(self, *args, **kwargs):
         self.widget = GeopositionWidget()
         fields = (
             forms.DecimalField(label=_('latitude')),
             forms.DecimalField(label=_('longitude')),
         )
-        super(GeopositionField, self).__init__(fields, required=False)
-    
+        kwargs['required'] = False
+        if 'initial' in kwargs:
+            kwargs['initial'] = Geoposition(*kwargs['initial'].split(','))
+        super(GeopositionField, self).__init__(fields, **kwargs)
+
     def widget_attrs(self, widget):
         classes = widget.attrs.get('class', '').split()
         classes.append('geoposition')
         return {'class': ' '.join(classes)}
-    
+
     def compress(self, value_list):
         if value_list:
             return value_list


### PR DESCRIPTION
This attempts to fix the same issue as #6.
- Admin tried to save rows with models with Geoposition fields rendered as tabular inline even if they were not _dirty_, because the check to see whether the form had changed thought it had. This was caused by initialisation problems
- It also passes along **kwargs to the base field class, so that things like `initial` can get through
