### PR TITLE
Add a custom event with lat, lng and address to further manipulation

### DIFF
--- a/geoposition/static/geoposition/geoposition.js
+++ b/geoposition/static/geoposition/geoposition.js
@@ -94,6 +94,12 @@ if (jQuery != undefined) {
                     $addressRow.text('');
                     if (results && results[0]) {
                         $addressRow.text(results[0].formatted_address);
+                        // Also trigger a custom event that needs to be captured
+                        $container.trigger("marker_dragged", {
+                          latitude : marker.position.lat(),
+                          longitude : marker.position.lng(),
+                          address : results[0].formatted_address
+                        })
                     }
                 });
             }


### PR DESCRIPTION
Hi @philippbosch , thanks for the plugin, it's really simple to use.

One thing I missed was a way to use the address as a field in my models, so I added a custom event to be fired when `doGeocode()` is performed. It makes the marker's lat, lng and address visible through it, so we can set up in a field in a form.

Thank you