### PR TITLE
Added support for Google API key

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Installation
 
 - Set your Google API key in you settings file::
 
-    GEOPOSITION_MAP_API_KEY = 'YOU_API_KEY'
+    GEOPOSITION_MAP_API_KEY = 'YOUR_API_KEY'
 
   API keys may be obtained here: https://developers.google.com/maps/documentation/javascript/get-api-key
 

--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,12 @@ Installation
         "geoposition",
     )
 
+- Set your Google API key in you settings file::
+
+    GEOPOSITION_MAP_API_KEY = 'YOU_API_KEY'
+
+  API keys may be obtained here: https://developers.google.com/maps/documentation/javascript/get-api-key
+
 - If you are still using Django <1.3, you are advised to install
   `django-staticfiles`_ for static file serving.
 

--- a/geoposition/widgets.py
+++ b/geoposition/widgets.py
@@ -42,7 +42,7 @@ class GeopositionWidget(forms.MultiWidget):
 
     class Media:
         js = (
-            '//maps.google.com/maps/api/js?sensor=false',
+            '//maps.google.com/maps/api/js?key=%s&sensor=false' % settings.GEOPOSITION_MAP_API_KEY,
             'geoposition/geoposition.js',
         )
         css = {


### PR DESCRIPTION
Since Google now requires API keys, here's a fix to make the app work again.

Related to issue #66 