### PR TITLE
Value conversion on assignment

### DIFF
--- a/geoposition/tests/test_geoposition.py
+++ b/geoposition/tests/test_geoposition.py
@@ -52,3 +52,7 @@ class GeopositionTestCase(TestCase):
         obj = PointOfInterest.objects.create(name='Foo', address='some where', city='city', zipcode='12345', position=Geoposition(52.5, 13.4))
         poi = PointOfInterest.objects.get(id=obj.id)
         self.assertIsInstance(poi.position, Geoposition)
+
+    def test_value_conversion_on_assignment(self):
+        obj = PointOfInterest(name='Foo', address='some where', city='city', zipcode='12345', position='52.5,13.4')
+        self.assertEqual(obj.position, Geoposition(52.5, 13.4))


### PR DESCRIPTION
Previous to https://github.com/philippbosch/django-geoposition/releases/tag/v0.3.0 the `GeopositionField` had the behaviour of converting the value on assignment. This default behaviour was changed after switching to "new-style" Django custom fields.

In order to maintain a consistent behaviour, a custom assignment descriptor is required.

See: https://github.com/hzdg/django-enumfields/pull/61
