### PR TITLE
Add django 1.11 support

### DIFF
--- a/geoposition/templates/geoposition/widgets/geoposition.html
+++ b/geoposition/templates/geoposition/widgets/geoposition.html
@@ -2,11 +2,23 @@
     <table>
         <tr>
             <td>{{ latitude.label|capfirst }}</td>
-            <td>{{ latitude.html }}</td>
+            <td>
+                {% if latitude.widget %}
+                    {% include latitude.widget.template_name with widget=latitude.widget %}
+                {% else %}
+                    {{ latitude.html }}
+                {% endif %}
+            </td>
         </tr>
         <tr>
             <td>{{ longitude.label|capfirst }}</td>
-            <td>{{ longitude.html }}</td>
+            <td>
+                {% if longitude.widget %}
+                    {% include longitude.widget.template_name with widget=longitude.widget %}
+                {% else %}
+                    {{ longitude.html }}
+                {% endif %}
+            </td>
         </tr>
     </table>
 </div>

--- a/geoposition/widgets.py
+++ b/geoposition/widgets.py
@@ -27,6 +27,14 @@ class GeopositionWidget(forms.MultiWidget):
             return [value.latitude, value.longitude]
         return [None, None]
 
+    def get_config(self):
+        return {
+            'map_widget_height': settings.MAP_WIDGET_HEIGHT or 500,
+            'map_options': json.dumps(settings.MAP_OPTIONS),
+            'marker_options': json.dumps(settings.MARKER_OPTIONS),
+        }
+
+
     def get_context(self, name, value, attrs):
         # Django 1.11 and up
         context = super(GeopositionWidget, self).get_context(name, value, attrs)
@@ -38,11 +46,7 @@ class GeopositionWidget(forms.MultiWidget):
             'widget': context['widget']['subwidgets'][1],
             'label': _("longitude"),
         }
-        context['config'] = {
-            'map_widget_height': settings.MAP_WIDGET_HEIGHT or 500,
-            'map_options': json.dumps(settings.MAP_OPTIONS),
-            'marker_options': json.dumps(settings.MARKER_OPTIONS),
-        }
+        context['config'] = self.get_config()
         return context
 
     def format_output(self, rendered_widgets):
@@ -56,11 +60,7 @@ class GeopositionWidget(forms.MultiWidget):
                 'html': rendered_widgets[1],
                 'label': _("longitude"),
             },
-            'config': {
-                'map_widget_height': settings.MAP_WIDGET_HEIGHT or 500,
-                'map_options': json.dumps(settings.MAP_OPTIONS),
-                'marker_options': json.dumps(settings.MARKER_OPTIONS),
-            }
+            'config': self.get_config(),
         })
 
     class Media:

--- a/geoposition/widgets.py
+++ b/geoposition/widgets.py
@@ -1,14 +1,18 @@
 from __future__ import unicode_literals
 
 import json
+
 from django import forms
 from django.template.loader import render_to_string
 from django.utils import six
 from django.utils.translation import ugettext_lazy as _
+
 from .conf import settings
 
 
 class GeopositionWidget(forms.MultiWidget):
+    template_name = 'geoposition/widgets/geoposition.html'
+
     def __init__(self, attrs=None):
         widgets = (
             forms.TextInput(),
@@ -23,7 +27,26 @@ class GeopositionWidget(forms.MultiWidget):
             return [value.latitude, value.longitude]
         return [None, None]
 
+    def get_context(self, name, value, attrs):
+        # Django 1.11 and up
+        context = super(GeopositionWidget, self).get_context(name, value, attrs)
+        context['latitude'] = {
+            'widget': context['widget']['subwidgets'][0],
+            'label': _("latitude"),
+        }
+        context['longitude'] = {
+            'widget': context['widget']['subwidgets'][1],
+            'label': _("longitude"),
+        }
+        context['config'] = {
+            'map_widget_height': settings.MAP_WIDGET_HEIGHT or 500,
+            'map_options': json.dumps(settings.MAP_OPTIONS),
+            'marker_options': json.dumps(settings.MARKER_OPTIONS),
+        }
+        return context
+
     def format_output(self, rendered_widgets):
+        # Django 1.10 and down
         return render_to_string('geoposition/widgets/geoposition.html', {
             'latitude': {
                 'html': rendered_widgets[0],


### PR DESCRIPTION
Will close #83.

Issue is django removed the `format_output` method from `forms.MultiWidget`, see https://docs.djangoproject.com/en/1.11/releases/1.11/#changes-due-to-the-introduction-of-template-based-widget-rendering.

I've tried to keep support for both >1.11 and <=1.10 by adding a `template_name` and `get_context` to `GeopositionWidget` but leaving the existing `format_output`.

It's working on 1.11, have not checked on 1.10 or 1.8.