### PR TITLE
Fix decimal Conversion Error

### DIFF
--- a/geoposition/__init__.py
+++ b/geoposition/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-from decimal import Decimal
+from decimal import Decimal, DecimalException
 
 default_app_config = 'geoposition.apps.GeoPositionConfig'
 
@@ -11,16 +11,19 @@ class Geoposition(object):
     def __init__(self, latitude, longitude):
         if isinstance(latitude, float) or isinstance(latitude, int):
             latitude = str(latitude)
-        else:
-            latitude = ''.join(i for i in latitude if i.isdigit())
             
         if isinstance(longitude, float) or isinstance(longitude, int):
             longitude = str(longitude)
-        else:
-            longitude = ''.join(i for i in longitude if i.isdigit())
 
-        self.latitude = Decimal(latitude)
-        self.longitude = Decimal(longitude)
+        try:
+            self.latitude = Decimal(latitude)
+        except DecimalException:
+            self.latitude = '0.0'
+
+        try:
+            self.longitude = Decimal(longitude)
+        except DecimalException:
+            self.longitude = '0.0'
 
     def __str__(self):
         return "%s,%s" % (self.latitude, self.longitude)

--- a/geoposition/__init__.py
+++ b/geoposition/__init__.py
@@ -11,8 +11,13 @@ class Geoposition(object):
     def __init__(self, latitude, longitude):
         if isinstance(latitude, float) or isinstance(latitude, int):
             latitude = str(latitude)
+        else:
+            latitude = ''.join(i for i in latitude if i.isdigit())
+            
         if isinstance(longitude, float) or isinstance(longitude, int):
             longitude = str(longitude)
+        else:
+            longitude = ''.join(i for i in longitude if i.isdigit())
 
         self.latitude = Decimal(latitude)
         self.longitude = Decimal(longitude)


### PR DESCRIPTION
I added Geoposition Field() into model and then when i migrate it asked me to enter a value for this field. I accidentally entered parentheses as a value, after the migration when i tried to access the page i got this error. 

<del>So in the init i just put an else to remove chars form numerics.</del>
I improved the solution to catch the DecimalException.  I think this way is more clean.

```
  File "/Users/cnone/venvManagerAPI/lib/python3.5/site-packages/geoposition/fields.py", line 41, in to_python
    return Geoposition(latitude, longitude)
  File "/Users/cnone/venvManagerAPI/lib/python3.5/site-packages/geoposition/__init__.py", line 18, in __init__
    self.latitude = Decimal(latitude)
decimal.InvalidOperation: [<class 'decimal.ConversionSyntax'>]
[20/Jun/2017 00:14:04] "GET /admin/mn_vendor/vendor/ HTTP/1.1" 500 142540
```

Or what should we do to avoid this kind of accident?