### PR TITLE
Rename global variable "django" in geoposition.js due to conflict with other admin libraries

### DIFF
--- a/geoposition/static/geoposition/geoposition.js
+++ b/geoposition/static/geoposition/geoposition.js
@@ -1,5 +1,5 @@
 if (jQuery != undefined) {
-    var django = {
+    var djangoGeoposition = {
         'jQuery': jQuery,
     }
 }
@@ -164,4 +164,4 @@ if (jQuery != undefined) {
             });
         });
     });
-})(django.jQuery);
+})(djangoGeoposition.jQuery);


### PR DESCRIPTION
Hello can we rename global variable `django` in `geoposition.js`. Some libraries like [django-jet](https://github.com/geex-arts/django-jet) call it instead of builtin one and get a name conflict.