### PR TITLE
docs: Fix simple typo, shat -> that

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -245,7 +245,7 @@ epub_copyright = u'2011, Philipp Bosch'
 # The format is a list of tuples containing the path and title.
 #epub_pre_files = []
 
-# HTML files shat should be inserted after the pages created by sphinx.
+# HTML files that should be inserted after the pages created by sphinx.
 # The format is a list of tuples containing the path and title.
 #epub_post_files = []
 


### PR DESCRIPTION
There is a small typo in docs/conf.py.

Should read `that` rather than `shat`.

